### PR TITLE
fix: TUI transcription mode and API key preservation bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriba"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,6 +54,8 @@ impl std::str::FromStr for LocalModelSize {
 pub struct ScribaConfig {
     pub transcription: TranscriptionMode,
     pub audio_settings: AudioSettings,
+    /// Stores the last used API key to preserve it when switching modes
+    pub last_api_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -76,6 +78,7 @@ impl Default for ScribaConfig {
                 channels: 1,
                 speech_optimized: true,
             },
+            last_api_key: None,
         }
     }
 }
@@ -125,6 +128,13 @@ impl ScribaConfig {
     }
 
     pub fn set_transcription_mode(&mut self, mode: TranscriptionMode) -> Result<()> {
+        // Save current API key if we're switching away from API mode
+        if let TranscriptionMode::Api { api_key } = &self.transcription {
+            if !api_key.is_empty() {
+                self.last_api_key = Some(api_key.clone());
+            }
+        }
+        
         self.transcription = mode;
         self.save()
     }

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -1,6 +1,6 @@
 use crate::database::{Database, Recording, RecordingStats};
 use crate::record::record_with_control;
-use crate::transcribe::transcribe_file_silent;
+use crate::transcribe::transcribe_file;
 use crate::audio::CompressionSettings;
 use crate::config::{ScribaConfig, TranscriptionMode, LocalModelSize};
 use tokio::sync::mpsc;
@@ -188,8 +188,10 @@ impl Dashboard {
                                 // Start transcription
                                 let input_path = PathBuf::from(&recording_name);
                                 let input_path_clone = input_path.clone();
+                                let output_path_clone = input_path.clone();
+                                let transcription_mode = self.config.transcription.clone();
                                 self.transcription_task = Some(tokio::spawn(async move {
-                                    transcribe_file_silent(&input_path_clone, Some(LocalModelSize::Turbo)).await
+                                    transcribe_file(&input_path_clone, &output_path_clone, Some(transcription_mode)).await
                                 }));
                             } else {
                                 // Recording only mode - complete
@@ -945,7 +947,11 @@ impl Dashboard {
                             // Toggle transcription mode
                             let new_mode = match &self.config.transcription {
                                 TranscriptionMode::Local { .. } => {
-                                    TranscriptionMode::Api { api_key: String::new() }
+                                    // Use preserved API key if available, otherwise empty
+                                    let api_key = self.config.last_api_key.as_ref()
+                                        .map(|key| key.clone())
+                                        .unwrap_or_else(String::new);
+                                    TranscriptionMode::Api { api_key }
                                 }
                                 TranscriptionMode::Api { .. } => {
                                     TranscriptionMode::Local { model_size: LocalModelSize::Medium }
@@ -1887,8 +1893,10 @@ impl Dashboard {
         
         // Start transcription in background task
         let input_path_clone = input_path.clone();
+        let output_path_clone = input_path.clone();
+        let transcription_mode = self.config.transcription.clone();
         self.transcription_task = Some(tokio::spawn(async move {
-            transcribe_file_silent(&input_path_clone, Some(LocalModelSize::Turbo)).await
+            transcribe_file(&input_path_clone, &output_path_clone, Some(transcription_mode)).await
         }));
         
         Ok(())


### PR DESCRIPTION
## 🐛 Bug Fixes

This PR resolves two critical issues with the TUI transcription system:

### 1. TUI Dashboard Not Using Configured Transcription Mode

**Problem**: The TUI dashboard was hardcoded to use local transcription with `LocalModelSize::Turbo`, ignoring the user's configured transcription mode (Local vs API).

**Root Cause**: 
- `transcribe_file_silent()` calls in dashboard.rs were hardcoded with `Some(LocalModelSize::Turbo)`
- The function only supported local models, not the full `TranscriptionMode` enum

**Solution**:
- ✅ Replace `transcribe_file_silent` with `transcribe_file` in dashboard.rs
- ✅ Pass `self.config.transcription.clone()` to respect user's configured mode
- ✅ Both record-and-transcribe and transcribe-selected operations now honor config

### 2. API Key Lost When Switching Modes in TUI Settings

**Problem**: When switching from Local → API mode in TUI settings, the API key was always reset to empty string, requiring users to re-enter it every time.

**Root Cause**: Mode switching logic used `TranscriptionMode::Api { api_key: String::new() }` without preserving existing keys.

**Solution**:
- ✅ Add `last_api_key: Option<String>` field to `ScribaConfig`
- ✅ Update `set_transcription_mode()` to save API key when switching away from API mode
- ✅ Update TUI mode switching to restore preserved API key when returning to API mode
- ✅ API keys now persist across Local ↔ API mode switches

## 🧪 Testing

### Before Fix:
```bash
# TUI would always use local transcription regardless of config
scriba config set-api "your-key"
# Dashboard transcription would still use local Whisper models

# API key would be lost when switching modes
# Settings: Local → API → Local → API (key gone)
```

### After Fix:
```bash
# TUI respects configured transcription mode
scriba config set-api "your-key" 
# Dashboard transcription now uses OpenAI API correctly

# API key preserved across mode switches  
# Settings: Local → API (key restored) → Local → API (key still there)
```

## 🔧 Technical Details

**Files Modified**:
- `src/config.rs`: Added `last_api_key` field and preservation logic
- `src/dashboard.rs`: Updated transcription calls and mode switching logic

**Backward Compatibility**: 
- ✅ Existing configs automatically get `last_api_key: None` 
- ✅ No breaking changes to existing functionality
- ✅ Previous API keys in existing configs are preserved

## 📋 Validation

- [x] CLI config commands work correctly
- [x] TUI transcription respects configured mode (Local/API)
- [x] API key preservation across mode switches
- [x] Backward compatibility with existing configs
- [x] All compilation tests pass

Resolves the transcription mode and API key persistence issues reported in v0.9.0.