### PR TITLE
fix: entity deduplication and alias-aware resolution (#33, #34)

### DIFF
--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -313,6 +313,14 @@ impl WorkflowManager {
             println!("  📊 Extracting metadata from transcript...");
         }
 
+        // Rebuild world from entities BEFORE extraction so LLM sees
+        // up-to-date aliases and merged entity state
+        if let Err(e) = rebuild_world_from_entities(&self.db_manager.db) {
+            if verbose {
+                eprintln!("  ⚠️ Failed to refresh world context: {}", e);
+            }
+        }
+
         // Load world context (Scriba's understanding of the owner)
         let world = WorldContext::load().unwrap_or_default();
         let world_content = if world.has_content() {
@@ -831,7 +839,7 @@ fn apply_world_delta_to_entities(db: &mut Database, delta: &WorldData) -> Result
 
     // Apply owner changes
     if !delta.owner.name.is_empty() {
-        if let Some(entity) = registry.get_entity_by_name(&delta.owner.name)? {
+        if let Some(entity) = registry.get_entity_by_name_or_alias(&delta.owner.name)? {
             let entity_id = entity.id.unwrap();
             for alias in &delta.owner.aliases {
                 registry.add_entity_alias(entity_id, alias)?;
@@ -844,7 +852,7 @@ fn apply_world_delta_to_entities(db: &mut Database, delta: &WorldData) -> Result
         if person.name.is_empty() {
             continue;
         }
-        match registry.get_entity_by_name(&person.name)? {
+        match registry.get_entity_by_name_or_alias(&person.name)? {
             Some(entity) => {
                 let entity_id = entity.id.unwrap();
                 if !person.relationship.is_empty() {
@@ -877,7 +885,7 @@ fn apply_world_delta_to_entities(db: &mut Database, delta: &WorldData) -> Result
         if org.name.is_empty() {
             continue;
         }
-        match registry.get_entity_by_name(&org.name)? {
+        match registry.get_entity_by_name_or_alias(&org.name)? {
             Some(entity) => {
                 let entity_id = entity.id.unwrap();
                 if !org.description.is_empty() {

--- a/src/database/repository.rs
+++ b/src/database/repository.rs
@@ -721,6 +721,31 @@ impl Database {
         }
     }
 
+    /// Get an entity by canonical name OR alias (case-insensitive).
+    ///
+    /// First checks canonical_name, then scans aliases JSON arrays.
+    /// This prevents recreating entities that were merged (where the old
+    /// name became an alias of the target entity).
+    pub fn get_entity_by_name_or_alias(&self, name: &str) -> Result<Option<Entity>> {
+        // First try canonical name (fast path)
+        if let Some(entity) = self.get_entity_by_name(name)? {
+            return Ok(Some(entity));
+        }
+
+        // Scan all entities for alias match
+        let name_lower = name.to_lowercase();
+        let all = self.list_entities(None, None)?;
+        for entity in all {
+            for alias in entity.aliases_list() {
+                if alias.to_lowercase() == name_lower {
+                    return Ok(Some(entity));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     /// List all entities, optionally filtered by type.
     pub fn list_entities(&self, entity_type: Option<&str>, limit: Option<i64>) -> Result<Vec<Entity>> {
         let sql = match (entity_type, limit) {

--- a/src/enrichment/prompts.rs
+++ b/src/enrichment/prompts.rs
@@ -25,6 +25,8 @@ Extract the following information and return it as a JSON object:
 6. "key_points": An array of key points or insights (3-5 items)
 7. "action_items": An array of action items or tasks mentioned (if any)
 
+IMPORTANT: If the same person or organization appears multiple times in the transcript (even with slight spelling variations), include them ONLY ONCE with combined context. Do NOT return duplicate entries.
+
 Return ONLY valid JSON, no additional text. If a field has no relevant content, use an empty array [] or empty string "".
 
 Example JSON structure (DO NOT copy these example values - extract from the actual transcript above):
@@ -299,9 +301,10 @@ Extract the following information and return it as a JSON object:
 
 ENTITY RESOLUTION RULES:
 - Transcripts often contain misspellings due to speech-to-text errors. "Exane", "Xane", "Hexane" could all be "Exein". Use the world context to resolve these.
-- If a name closely resembles a known person or organization from the world, resolve it.
+- If a name closely resembles a known person or organization from the world, resolve it. Check BOTH names AND aliases in the world context.
 - If a name is genuinely new (not in the world at all), set "resolved_to" to null.
 - When in doubt, resolve to the known entity rather than creating a new one.
+- DEDUPLICATION: If the same person or organization appears multiple times in the transcript (even with slight spelling variations), include them ONLY ONCE with combined context. Do NOT return duplicate entries.
 
 Return ONLY valid JSON, no additional text. If a field has no relevant content, use an empty array [] or empty string "".
 

--- a/src/entities/linker.rs
+++ b/src/entities/linker.rs
@@ -1,8 +1,12 @@
 //! Entity linking using LLM-resolved entities.
 //!
 //! The LLM extraction prompt already resolves entities against the world context.
-//! This module simply links resolved entities to their DB records and creates
-//! new entities for unresolved ones.
+//! This module links resolved entities to their DB records (checking both canonical
+//! names and aliases) and creates new entities for genuinely unresolved ones.
+//! Extraction results are deduplicated before processing to prevent duplicate
+//! entity creation within a single extraction.
+
+use std::collections::HashMap;
 
 use anyhow::Result;
 
@@ -14,17 +18,76 @@ use super::registry::EntityRegistry;
 /// Entity linker that processes LLM-resolved extraction results.
 pub struct EntityLinker;
 
+/// A deduplicated entity: same canonical name, merged contexts.
+struct DeduplicatedEntity {
+    canonical_name: String,
+    transcript_names: Vec<String>,
+    context: String,
+    entity_type: String,
+}
+
 impl EntityLinker {
     /// Create a new entity linker.
     pub fn new() -> Self {
         Self
     }
 
+    /// Deduplicate extracted entities by canonical name.
+    ///
+    /// If the LLM returns "Steve" twice with different contexts,
+    /// merge them into a single entry with combined context.
+    fn deduplicate_entities(extraction: &ExtractionResult) -> Vec<DeduplicatedEntity> {
+        let mut seen: HashMap<String, DeduplicatedEntity> = HashMap::new();
+
+        for (entity, entity_type) in extraction.all_entities() {
+            let canonical = entity
+                .resolved_to
+                .as_deref()
+                .unwrap_or(&entity.name)
+                .to_lowercase();
+
+            if let Some(existing) = seen.get_mut(&canonical) {
+                // Merge context if different
+                if !existing.context.contains(&entity.context) {
+                    existing.context = format!("{}; {}", existing.context, entity.context);
+                }
+                // Track all transcript names for alias creation
+                if !existing
+                    .transcript_names
+                    .iter()
+                    .any(|n| n.to_lowercase() == entity.name.to_lowercase())
+                {
+                    existing.transcript_names.push(entity.name.clone());
+                }
+            } else {
+                // Use the original-case canonical name
+                let canonical_name = entity
+                    .resolved_to
+                    .as_deref()
+                    .unwrap_or(&entity.name)
+                    .to_string();
+
+                seen.insert(
+                    canonical.clone(),
+                    DeduplicatedEntity {
+                        canonical_name,
+                        transcript_names: vec![entity.name.clone()],
+                        context: entity.context.clone(),
+                        entity_type: entity_type.to_string(),
+                    },
+                );
+            }
+        }
+
+        seen.into_values().collect()
+    }
+
     /// Process extraction results and link/create entities.
     ///
-    /// For each extracted entity:
-    /// - If `resolved_to` is set, find the known entity by canonical name and link
-    /// - If `resolved_to` is null, create a new entity
+    /// Deduplicates extraction results first, then for each entity:
+    /// - Searches by canonical name AND aliases (catches merged entities)
+    /// - If found, links to existing entity
+    /// - If not found, creates a new entity
     pub fn process_extraction(
         &self,
         db: &mut Database,
@@ -33,72 +96,84 @@ impl EntityLinker {
     ) -> Result<LinkingReport> {
         let mut report = LinkingReport::default();
 
-        for (entity, entity_type) in extraction.all_entities() {
+        let deduped = Self::deduplicate_entities(extraction);
+
+        for entity in &deduped {
             let mut registry = EntityRegistry::new(db);
 
-            // Determine the canonical name: use resolved_to if available, otherwise the transcript name
-            let canonical_name = entity.resolved_to.as_deref().unwrap_or(&entity.name);
-
-            // Try to find existing entity by canonical name
-            let existing = registry.get_entity_by_name(canonical_name)?;
+            // Try to find existing entity by canonical name OR alias
+            let existing = registry.get_entity_by_name_or_alias(&entity.canonical_name)?;
 
             if let Some(existing_entity) = existing {
                 let entity_id = existing_entity.id.unwrap();
 
-                // Link mention to existing entity
-                registry.create_mention(
-                    recording_id,
-                    &entity.name,
-                    Some(&entity.context),
-                    Some(entity_id),
-                    1.0,
-                )?;
+                // Create mention records for each transcript name
+                for name in &entity.transcript_names {
+                    registry.create_mention(
+                        recording_id,
+                        name,
+                        Some(&entity.context),
+                        Some(entity_id),
+                        1.0,
+                    )?;
+                }
 
                 // Increment mention count
                 registry.record_mention(entity_id)?;
 
-                // Add transcript name as alias if different from canonical
-                if entity.name.to_lowercase() != canonical_name.to_lowercase() {
-                    registry.add_entity_alias(entity_id, &entity.name)?;
+                // Add transcript names as aliases if different from canonical
+                for name in &entity.transcript_names {
+                    if name.to_lowercase() != existing_entity.canonical_name.to_lowercase()
+                        && !existing_entity
+                            .aliases_list()
+                            .iter()
+                            .any(|a| a.to_lowercase() == name.to_lowercase())
+                    {
+                        registry.add_entity_alias(entity_id, name)?;
+                    }
                 }
 
                 report.linked_existing += 1;
                 report.details.push(LinkDetail {
-                    mention_text: entity.name.clone(),
+                    mention_text: entity.transcript_names.join(", "),
                     action: LinkAction::LinkedExisting,
                     entity_id: Some(entity_id),
-                    canonical_name: canonical_name.to_string(),
+                    canonical_name: entity.canonical_name.clone(),
                 });
             } else {
                 // Create new entity
                 let new_entity = registry.create_entity(
-                    entity_type,
-                    canonical_name,
+                    &entity.entity_type,
+                    &entity.canonical_name,
                     Some(&entity.context),
                 )?;
 
                 let new_id = new_entity.id.unwrap();
 
-                // Add transcript name as alias if different
-                if entity.name.to_lowercase() != canonical_name.to_lowercase() {
-                    registry.add_entity_alias(new_id, &entity.name)?;
+                // Add transcript names as aliases if different
+                for name in &entity.transcript_names {
+                    if name.to_lowercase() != entity.canonical_name.to_lowercase() {
+                        registry.add_entity_alias(new_id, name)?;
+                    }
                 }
 
-                // Create mention record
-                registry.create_mention(
-                    recording_id,
-                    &entity.name,
-                    Some(&entity.context),
-                    new_entity.id,
-                    1.0,
-                )?;
+                // Create mention records
+                for name in &entity.transcript_names {
+                    registry.create_mention(
+                        recording_id,
+                        name,
+                        Some(&entity.context),
+                        new_entity.id,
+                        1.0,
+                    )?;
+                }
 
                 report.created_new += 1;
                 report.details.push(LinkDetail {
-                    mention_text: entity.name.clone(),
+                    mention_text: entity.transcript_names.join(", "),
                     action: LinkAction::CreatedNew,
                     entity_id: new_entity.id,
-                    canonical_name: canonical_name.to_string(),
+                    canonical_name: entity.canonical_name.clone(),
                 });
             }
         }

--- a/src/entities/registry.rs
+++ b/src/entities/registry.rs
@@ -56,6 +56,11 @@ impl<'a> EntityRegistry<'a> {
         self.db.get_entity_by_name(name)
     }
 
+    /// Get an entity by canonical name or alias.
+    pub fn get_entity_by_name_or_alias(&self, name: &str) -> Result<Option<Entity>> {
+        self.db.get_entity_by_name_or_alias(name)
+    }
+
     /// List all entities, optionally filtered by type.
     pub fn list_entities(
         &self,


### PR DESCRIPTION
## Summary

Fixes two related entity management bugs:

### Bug #33: Duplicate entities created for same name
When the LLM returned the same person multiple times in one extraction (e.g. "Steve" mentioned in two parts of a transcript), each instance created a separate entity.

**Fix**: 
- Extraction results are now deduplicated by canonical name before processing in the linker
- Deduplication instruction added to both extraction prompts

### Bug #34: Merged entities recreated on next enrichment
After merging entities in the TUI (e.g. "Vincenzo" → alias of "Vincent"), the next enrichment would recreate "Vincenzo" as a new entity.

**Fix**:
- New `get_entity_by_name_or_alias()` searches both canonical names and aliases
- Used in linker, world delta application, and registry
- World context rebuilt BEFORE extraction so LLM sees up-to-date aliases
- Extraction prompt now instructs LLM to check aliases when resolving

### Files changed
- `src/database/repository.rs` — `get_entity_by_name_or_alias()`
- `src/entities/registry.rs` — expose alias-aware lookup
- `src/entities/linker.rs` — dedup + alias-aware linking
- `src/core/workflow.rs` — rebuild world before extraction, alias-aware delta
- `src/enrichment/prompts.rs` — dedup + alias hints in prompts

Closes #33, closes #34