### PR TITLE
feat: Whisper world prompt & entity quality fixes (#39)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scriba"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scriba"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 description = "A CLI tool for recording and transcribing audio locally using Whisper (whisper-rs)"
 authors = ["Giovanni Alberto Falcione"]

--- a/Formula/scriba.rb
+++ b/Formula/scriba.rb
@@ -1,20 +1,20 @@
 class Scriba < Formula
   desc "Modern CLI tool for recording and transcribing audio using OpenAI Whisper"
   homepage "https://github.com/giovannialberto/scriba"
-  version "0.15.2"
-  
+  version "0.16.0"
+
   if Hardware::CPU.intel?
-    url "https://github.com/giovannialberto/scriba/releases/download/v0.15.2/scriba-x86_64-apple-darwin"
-    sha256 "9b60fd52e8f9cc9f394c8be0571638eef3667ade841f235f915179057d33493b"
+    url "https://github.com/giovannialberto/scriba/releases/download/v0.16.0/scriba-x86_64-apple-darwin"
+    sha256 "PLACEHOLDER"
   else
-    url "https://github.com/giovannialberto/scriba/releases/download/v0.15.2/scriba-aarch64-apple-darwin"
-    sha256 "fa22dad084fe785068788a8f380b8ddb3afb45646523e2dfa106272b70f945ec"
+    url "https://github.com/giovannialberto/scriba/releases/download/v0.16.0/scriba-aarch64-apple-darwin"
+    sha256 "PLACEHOLDER"
   end
-  
+
   def install
     bin.install "scriba-#{Hardware::CPU.intel? ? "x86_64" : "aarch64"}-apple-darwin" => "scriba"
   end
-  
+
   test do
     assert_match version.to_s, shell_output("#{bin}/scriba --version")
   end

--- a/src/core/transcription.rs
+++ b/src/core/transcription.rs
@@ -19,6 +19,7 @@ use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextPar
 use super::config::{LocalModelSize, ScribaConfig, TranscriptionMode};
 use super::files::FileManager;
 use crate::database::Database;
+use crate::enrichment::{WorldContext, WorldData};
 use crate::utils::BASE_PATH;
 
 extern "C" {
@@ -339,6 +340,149 @@ async fn download_file_streaming(url: &str, dest: &Path, quiet: bool) -> Result<
     Ok(())
 }
 
+/// Approximate max characters for ~224 Whisper tokens.
+const WHISPER_PROMPT_CHAR_LIMIT: usize = 670;
+
+/// Filter aliases to only include genuine spelling variants, not LLM annotations.
+fn filter_aliases(aliases: &[String], canonical_name: &str) -> Vec<String> {
+    let canonical_lower = canonical_name.to_lowercase();
+    aliases
+        .iter()
+        .filter(|a| {
+            let lower = a.to_lowercase();
+            lower != canonical_lower && !a.contains('(') && a.len() <= 30
+        })
+        .cloned()
+        .collect()
+}
+
+/// Build a Whisper initial prompt from structured world data.
+///
+/// Returns a natural-language contextual string that primes Whisper's decoder
+/// with proper nouns, roles, and relationships for better transcription accuracy.
+fn build_prompt_from_world_data(data: &WorldData) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+
+    // 1) Owner — contextual sentence about who owns this instance
+    if !data.owner.name.is_empty() {
+        let name = &data.owner.name;
+        let aliases = filter_aliases(&data.owner.aliases, name);
+        let role = &data.owner.role;
+        let org = &data.owner.organization;
+
+        let mut sentence = if !role.is_empty() && !org.is_empty() {
+            format!("{} is the {} at {}", name, role, org)
+        } else if !role.is_empty() {
+            format!("{} is a {}", name, role)
+        } else if !org.is_empty() {
+            format!("{} works at {}", name, org)
+        } else {
+            format!("{} is the owner of this recording", name)
+        };
+
+        if !aliases.is_empty() {
+            sentence.push_str(&format!(", also known as {}", aliases.join(", ")));
+        }
+
+        sentence.push_str(". It is likely that he is involved in this conversation.");
+        parts.push(sentence);
+    }
+
+    // 2) People — natural sentence with roles/relationships
+    if !data.people.is_empty() {
+        let people_descriptions: Vec<String> = data
+            .people
+            .iter()
+            .map(|p| {
+                let aliases = filter_aliases(&p.aliases, &p.name);
+                let mut desc = p.name.clone();
+                if !aliases.is_empty() {
+                    desc.push_str(&format!(" ({})", aliases.join(", ")));
+                }
+                if !p.relationship.is_empty() && !p.relationship.starts_with('{') {
+                    desc.push_str(&format!(", {}", p.relationship));
+                }
+                desc
+            })
+            .collect();
+        parts.push(format!(
+            "Common people he interacts with: {}.",
+            people_descriptions.join("; ")
+        ));
+    }
+
+    // 3) Organizations — with descriptions
+    if !data.organizations.is_empty() {
+        let org_descriptions: Vec<String> = data
+            .organizations
+            .iter()
+            .map(|o| {
+                let aliases = filter_aliases(&o.aliases, &o.name);
+                let mut desc = o.name.clone();
+                if !aliases.is_empty() {
+                    desc.push_str(&format!(" ({})", aliases.join(", ")));
+                }
+                if !o.description.is_empty() && !o.description.starts_with('{') {
+                    desc.push_str(&format!(", {}", o.description));
+                }
+                desc
+            })
+            .collect();
+        parts.push(format!(
+            "Organizations: {}.",
+            org_descriptions.join("; ")
+        ));
+    }
+
+    // 4) Projects and interests — domain vocabulary
+    let mut topics: Vec<String> = Vec::new();
+    for p in &data.projects {
+        topics.push(p.name.clone());
+    }
+    for i in &data.interests {
+        topics.push(i.clone());
+    }
+    if !topics.is_empty() {
+        parts.push(format!("Topics often discussed: {}.", topics.join(", ")));
+    }
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    // Assemble with budget enforcement
+    let mut prompt = String::new();
+    for part in &parts {
+        let candidate = if prompt.is_empty() {
+            part.clone()
+        } else {
+            format!("{} {}", prompt, part)
+        };
+        if candidate.len() > WHISPER_PROMPT_CHAR_LIMIT {
+            break;
+        }
+        prompt = candidate;
+    }
+
+    // Strip null bytes (set_initial_prompt panics on them)
+    let prompt = prompt.replace('\0', "");
+
+    if prompt.is_empty() {
+        None
+    } else {
+        Some(prompt)
+    }
+}
+
+/// Load world context and build a Whisper initial prompt.
+///
+/// Returns `None` if no world context exists or it cannot be parsed.
+fn build_whisper_world_prompt() -> Option<String> {
+    let world_ctx = WorldContext::load().ok()?;
+    let data = world_ctx.parsed()?;
+    build_prompt_from_world_data(&data)
+}
+
 fn run_whisper_transcription(model_path: &Path, wav_path: &Path) -> Result<String> {
     if !model_path.exists() {
         return Err(anyhow::anyhow!(
@@ -399,6 +543,10 @@ fn run_whisper_transcription(model_path: &Path, wav_path: &Path) -> Result<Strin
     params.set_print_timestamps(false);
     params.set_single_segment(false);
     params.set_n_threads(num_cpus::get() as i32);
+
+    if let Some(world_prompt) = build_whisper_world_prompt() {
+        params.set_initial_prompt(&world_prompt);
+    }
 
     state
         .full(params, &samples_f32)
@@ -591,4 +739,146 @@ pub async fn transcribe_audio(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::enrichment::world::{OrgInfo, OwnerInfo, PersonInfo, ProjectInfo};
+
+    #[test]
+    fn test_filter_aliases_removes_canonical_match() {
+        let aliases = vec!["giovanni".to_string()];
+        let result = filter_aliases(&aliases, "Giovanni");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_filter_aliases_removes_annotations_with_parens() {
+        let aliases = vec![
+            "Gio".to_string(),
+            "Giovanni (in the owner's world)".to_string(),
+        ];
+        let result = filter_aliases(&aliases, "Giovanni");
+        assert_eq!(result, vec!["Gio"]);
+    }
+
+    #[test]
+    fn test_filter_aliases_removes_long_aliases() {
+        let aliases = vec![
+            "Exane".to_string(),
+            "This is an extremely long alias that should be filtered out".to_string(),
+        ];
+        let result = filter_aliases(&aliases, "Exein");
+        assert_eq!(result, vec!["Exane"]);
+    }
+
+    #[test]
+    fn test_filter_aliases_keeps_genuine_variants() {
+        let aliases = vec!["Exane".to_string(), "Saci".to_string()];
+        let result = filter_aliases(&aliases, "Exein");
+        assert_eq!(result, vec!["Exane", "Saci"]);
+    }
+
+    #[test]
+    fn test_build_prompt_empty_world() {
+        let data = WorldData::default();
+        assert!(build_prompt_from_world_data(&data).is_none());
+    }
+
+    #[test]
+    fn test_build_prompt_owner_only() {
+        let data = WorldData {
+            owner: OwnerInfo {
+                name: "Giovanni".to_string(),
+                aliases: vec!["Gio".to_string()],
+                role: "CTO".to_string(),
+                organization: "Exein".to_string(),
+                location: String::new(),
+            },
+            ..Default::default()
+        };
+        let prompt = build_prompt_from_world_data(&data).unwrap();
+        assert!(prompt.contains("Giovanni is the CTO at Exein"));
+        assert!(prompt.contains("also known as Gio"));
+        assert!(prompt.contains("likely that he is involved"));
+    }
+
+    #[test]
+    fn test_build_prompt_full_world() {
+        let data = WorldData {
+            owner: OwnerInfo {
+                name: "Giovanni".to_string(),
+                aliases: vec![],
+                role: "CTO".to_string(),
+                organization: "Exein".to_string(),
+                location: String::new(),
+            },
+            people: vec![
+                PersonInfo {
+                    name: "Gerardo".to_string(),
+                    relationship: "CFO of Exein".to_string(),
+                    aliases: vec!["Gerardo Gagliardo".to_string()],
+                },
+                PersonInfo {
+                    name: "Steve".to_string(),
+                    relationship: String::new(),
+                    aliases: vec![],
+                },
+            ],
+            organizations: vec![OrgInfo {
+                name: "Exein".to_string(),
+                description: "cybersecurity company".to_string(),
+                aliases: vec!["Exane".to_string()],
+            }],
+            projects: vec![ProjectInfo {
+                name: "ASPISEC".to_string(),
+                description: String::new(),
+            }],
+            interests: vec!["cybersecurity".to_string()],
+            beliefs: vec![],
+        };
+        let prompt = build_prompt_from_world_data(&data).unwrap();
+        assert!(prompt.contains("Giovanni is the CTO at Exein"));
+        assert!(prompt.contains("Common people he interacts with"));
+        assert!(prompt.contains("Gerardo (Gerardo Gagliardo), CFO of Exein"));
+        assert!(prompt.contains("Steve"));
+        assert!(prompt.contains("Exein (Exane), cybersecurity company"));
+        assert!(prompt.contains("ASPISEC"));
+        assert!(prompt.contains("cybersecurity"));
+    }
+
+    #[test]
+    fn test_build_prompt_respects_char_limit() {
+        let data = WorldData {
+            owner: OwnerInfo {
+                name: "Owner".to_string(),
+                ..Default::default()
+            },
+            people: (0..200)
+                .map(|i| PersonInfo {
+                    name: format!("Person{}", i),
+                    relationship: String::new(),
+                    aliases: vec![],
+                })
+                .collect(),
+            ..Default::default()
+        };
+        let prompt = build_prompt_from_world_data(&data).unwrap();
+        assert!(prompt.len() <= WHISPER_PROMPT_CHAR_LIMIT);
+    }
+
+    #[test]
+    fn test_build_prompt_strips_null_bytes() {
+        let data = WorldData {
+            owner: OwnerInfo {
+                name: "Test\0Name".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let prompt = build_prompt_from_world_data(&data).unwrap();
+        assert!(!prompt.contains('\0'));
+        assert!(prompt.contains("TestName"));
+    }
 }

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -856,9 +856,18 @@ async fn apply_world_delta_to_entities(
         }
     }
 
+    // Generic placeholder names that should never become entities
+    let blocked_names: &[&str] = &[
+        "speaker", "speakers", "narrator", "author", "autore",
+        "owner", "user", "host", "interviewer", "interviewee",
+        "participant", "moderator", "presenter", "listener",
+        "the speaker", "the owner", "the author", "the narrator",
+        "you", "me", "i", "we", "they",
+    ];
+
     // Apply people changes
     for person in &delta.people {
-        if person.name.is_empty() {
+        if person.name.is_empty() || blocked_names.contains(&person.name.to_lowercase().as_str()) {
             continue;
         }
         match registry.get_entity_by_name_or_alias(&person.name)? {
@@ -949,6 +958,18 @@ async fn compact_or_append(
     verbose: bool,
 ) -> String {
     if existing_context.is_empty() {
+        return new_info.to_string();
+    }
+
+    // Skip compaction if the new info adds nothing beyond what's already known
+    if existing_context.trim() == new_info.trim()
+        || existing_context.to_lowercase().contains(&new_info.to_lowercase())
+    {
+        return existing_context.to_string();
+    }
+
+    // If the new info is a superset of existing, just use it directly
+    if new_info.to_lowercase().contains(&existing_context.to_lowercase()) {
         return new_info.to_string();
     }
 

--- a/src/enrichment/extractor.rs
+++ b/src/enrichment/extractor.rs
@@ -300,15 +300,17 @@ impl EnrichmentService {
             .await
             .context("Failed to compact entity context")?;
 
-        // Clean up: remove quotes, trim whitespace
+        // Clean up: remove quotes, markdown fences, trim whitespace
         let compacted = response
             .trim()
+            .trim_start_matches("```")
+            .trim_end_matches("```")
             .trim_matches('"')
             .trim()
             .to_string();
 
-        if compacted.is_empty() {
-            // LLM returned empty — keep existing + new as fallback
+        if compacted.is_empty() || compacted.starts_with('{') || compacted.starts_with('[') {
+            // LLM returned empty or JSON instead of plain text — fall back
             Ok(format!("{}. {}", existing_context.trim_end_matches('.'), new_info))
         } else {
             Ok(compacted)

--- a/src/enrichment/prompts.rs
+++ b/src/enrichment/prompts.rs
@@ -103,38 +103,24 @@ Return ONLY valid JSON:"#,
     )
 }
 
-/// Build a prompt for compacting an entity's context with new information.
+/// Build a prompt for updating an entity description with new information.
 ///
-/// Merges existing context + new facts into a single clean, self-contained
-/// description in one LLM call. Replaces the old `append_new_facts()` approach.
+/// Takes what we currently know and new facts, asks the LLM to produce
+/// a single updated description.
 pub fn build_context_compaction_prompt(
     entity_name: &str,
-    entity_type: &str,
+    _entity_type: &str,
     existing_context: &str,
     new_info: &str,
 ) -> String {
     format!(
-        r#"You are maintaining a knowledge base entry for a {entity_type} named "{entity_name}".
-
-CURRENT DESCRIPTION:
+        r#"What we know about "{entity_name}":
 {existing_context}
 
-NEW INFORMATION:
+New information:
 {new_info}
 
-YOUR TASK: Merge ALL facts from both sources into a single clean, self-contained description of "{entity_name}".
-
-RULES:
-1. PRESERVE every meaningful fact from both sources — do not drop details
-2. REMOVE redundant or repetitive statements
-3. If new information contradicts old information, prefer the newer information
-4. Write in a neutral, factual tone — like a concise encyclopedia entry
-5. The result must read as a polished summary, NOT an append log
-6. Keep it concise but complete (aim for 1-3 sentences)
-7. Do NOT add any preamble, explanation, or formatting — return ONLY the merged description text
-
-MERGED DESCRIPTION:"#,
-        entity_type = entity_type,
+Write an updated 1-2 sentence description of "{entity_name}" combining everything above. Be concise and factual. Only return the description, nothing else."#,
         entity_name = entity_name,
         existing_context = existing_context,
         new_info = new_info
@@ -199,6 +185,8 @@ RULES:
 - For projects: only include active projects the owner is working on
 - For beliefs: only include strong convictions the owner clearly expressed
 - Keep descriptions SHORT (under 15 words each)
+- ALL string values MUST be plain text, NEVER nested JSON objects or arrays. For example: "relationship": "Giovanni's girlfriend" NOT "relationship": {{"key": "value"}}
+- "description" and "relationship" fields are short plain-text sentences, nothing else
 
 Return ONLY valid JSON, nothing else:"#,
         current_world = current_world,
@@ -244,6 +232,7 @@ RULES:
 - Do NOT invent or assume information not present
 - Leave arrays empty if nothing relevant is mentioned
 - Keep descriptions SHORT (under 15 words)
+- ALL string values MUST be plain text, NEVER nested JSON objects or arrays
 
 Return ONLY valid JSON, nothing else."#,
         world_content = world_content

--- a/src/entities/linker.rs
+++ b/src/entities/linker.rs
@@ -32,6 +32,21 @@ impl EntityLinker {
         Self
     }
 
+    /// Names that should never become entities — generic placeholders the LLM
+    /// sometimes returns despite being told not to.
+    const BLOCKED_NAMES: &'static [&'static str] = &[
+        "speaker", "speakers", "narrator", "author", "autore",
+        "owner", "user", "host", "interviewer", "interviewee",
+        "participant", "moderator", "presenter", "listener",
+        "the speaker", "the owner", "the author", "the narrator",
+        "you", "me", "i", "we", "they",
+    ];
+
+    fn is_blocked_name(name: &str) -> bool {
+        let lower = name.to_lowercase();
+        Self::BLOCKED_NAMES.iter().any(|b| lower == *b)
+    }
+
     /// Deduplicate extracted entities by canonical name.
     ///
     /// If the LLM returns "Steve" twice with different contexts,
@@ -40,6 +55,15 @@ impl EntityLinker {
         let mut seen: HashMap<String, DeduplicatedEntity> = HashMap::new();
 
         for (entity, entity_type) in extraction.all_entities() {
+            // Skip generic placeholder names
+            let canonical_name_raw = entity
+                .resolved_to
+                .as_deref()
+                .unwrap_or(&entity.name);
+            if Self::is_blocked_name(canonical_name_raw) || Self::is_blocked_name(&entity.name) {
+                continue;
+            }
+
             let canonical = entity
                 .resolved_to
                 .as_deref()


### PR DESCRIPTION
## What

- **Whisper world prompt**: Feed world context to Whisper's `initial_prompt` parameter to improve proper noun transcription. Builds a natural-language prompt from WorldData (owner, people, orgs, projects, aliases) within ~224 token budget.
- **Entity context quality fixes**: Fix compaction producing JSON instead of plain text; skip redundant compaction; reject JSON responses as safety net.
- **Placeholder entity blocklist**: Filter out generic names like "speaker", "owner", "you" that LLMs create despite being told not to.
- **Simpler compaction prompt**: More natural entity descriptions.
- **Plain-text constraints**: Added to world evolution and seed extraction prompts.

## Files changed

| File | Change |
|------|--------|
| `src/core/transcription.rs` | Whisper prompt builder + `set_initial_prompt()` wiring + 9 unit tests |
| `src/core/workflow.rs` | Smart compaction skipping + entity blocklist |
| `src/enrichment/extractor.rs` | Reject JSON from compaction |
| `src/enrichment/prompts.rs` | Simpler compaction prompt + plain-text constraints |
| `src/entities/linker.rs` | Placeholder entity name blocklist |

## Testing

- 30 unit tests passing
- Full enrichment pipeline tested against 10 recordings with clean results

Closes #39