### PR TITLE
feat: add Linux installation support

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,0 @@
-# .env.template
-
-# OpenAI API Key
-# Copy this template to .env and replace the placeholder with your actual API key
-OPENAI_API_KEY=your_actual_api_key_here

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,8 +178,8 @@ jobs:
             cp ../Formula/scriba.rb Formula/scriba.rb
             
             # Commit and push to tap
-            git config user.email "action@github.com"
-            git config user.name "GitHub Action"
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add Formula/scriba.rb
             if git diff --cached --quiet; then
               echo "No tap formula changes to commit."

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ scriba.db-*
 
 # Rust build artifacts
 /target
-Cargo.lock
 
 # Debug files
 debug.log

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,79 @@
+# Scriba
+
+Rust TUI that records audio, transcribes it (local or cloud), enriches it with LLM-powered entity extraction and summaries, and lets you query your entire recording history through an agent chat.
+
+## Build & Run
+
+```bash
+cargo build                  # debug build
+cargo build --release        # release build
+cargo run                    # launch TUI dashboard
+cargo test                   # run all tests (~32 tests, <1s)
+cargo fmt --all              # format
+cargo clippy -- -D warnings  # lint
+```
+
+## Architecture
+
+```
+src/
+  main.rs              CLI entry point (StructOpt)
+  lib.rs               Public module exports
+  core/                Business logic (no UI deps)
+    recording.rs       Audio capture via cpal
+    transcription.rs   STT: sherpa-onnx (local) + OpenAI API
+    workflow.rs        Orchestration: record -> transcribe -> enrich
+    loopback.rs        System audio capture (macOS: ScreenCaptureKit, Linux: PulseAudio/PipeWire)
+    config.rs          ScribaConfig, TranscriptionMode, EnrichmentMode
+  database/            SQLite persistence (schema.sql at repo root, included at compile time)
+  enrichment/          LLM integration (Ollama, Anthropic, OpenAI, Google)
+    world.rs           Knowledge graph (WorldData), single source of truth
+    extractor.rs       Entity/topic extraction from transcripts
+    prompts.rs         All LLM prompts for extraction and evolution
+    chat_prompts.rs    Chat system prompts (agent + fallback)
+  agent/               Agent loop with tool use (Anthropic provider)
+    providers/         Per-provider implementations
+  entities/            Entity registry and linking (LLM-driven, no fuzzy matching)
+  tui/                 Terminal UI (ratatui)
+    app.rs             Main dashboard, navigation, key handling
+    chat.rs            Chat interface, streaming, rendering
+    browse.rs          Recording browser
+    entities.rs        Entity browser/editor
+    onboarding.rs      First-run setup flow
+    settings.rs        Settings UI
+    transcript.rs      Transcript viewer
+    recording.rs       Recording UI
+  mcp/                 Model Context Protocol server for Claude Desktop
+  tools/               Tool definitions and executor for agent
+```
+
+## Key conventions
+
+- **Edition 2024** — match ergonomics require no `ref`/`ref mut` on auto-deref patterns; `unsafe` blocks required inside `unsafe fn`
+- **Conventional Commits** — `feat:`, `fix:`, `chore:`, `docs:`. Subject ≤72 chars, imperative mood
+- **No co-author trailers** in commits
+- **Branches for PRs** — don't commit directly to main
+- **Focused PRs** — one concern per PR, no kitchen-sink changes
+- **`anyhow::Result`** throughout; `#[serde(default)]` on all LLM-facing struct fields
+- **TUI is modular** — each view in its own file under `tui/`, keep it that way
+- **World = single source of truth** — DB entities are a materialized index derived from `~/scriba_recordings/world.md`
+- **Entity linking is LLM-driven** — no fuzzy matching, no substring scanning
+
+## Release process
+
+1. Bump version in `Cargo.toml`
+2. Commit: `chore: bump version to X.Y.Z`
+3. Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+4. CI builds macOS (x86_64 + ARM64) and Linux (x86_64) binaries, creates GitHub release, updates Homebrew formula
+
+## Platform support
+
+- **macOS**: system audio via ScreenCaptureKit, mic via cpal, install via Homebrew
+- **Linux**: system audio via PulseAudio/PipeWire monitor sources, mic via cpal/ALSA, install via `install.sh` or GitHub releases
+- Platform-specific code gated with `#[cfg(target_os = "...")]` in `loopback.rs`
+
+## Testing
+
+- Unit tests inline: `#[cfg(test)] mod tests { ... }`
+- Tests cover: world merging, prompt generation, JSON extraction, search queries, ring buffer, Ollama client
+- Avoid external API calls in tests

--- a/README.md
+++ b/README.md
@@ -27,11 +27,33 @@ Run entirely **offline** with local STT models (Parakeet, Whisper, SenseVoice) +
 
 ## Get started
 
-**Requirements:** FFmpeg (`brew install ffmpeg`). Ollama is optional, for Private mode.
+**Requirements:** FFmpeg and (optionally) Ollama for Private mode.
+
+### macOS
 
 ```bash
+brew install ffmpeg
 brew tap giovannialberto/scriba
 brew install scriba
+```
+
+### Linux
+
+```bash
+# Install dependencies (Debian/Ubuntu)
+sudo apt install ffmpeg libasound2-dev
+
+# Install scriba
+curl -fsSL https://raw.githubusercontent.com/giovannialberto/scriba/main/install.sh | sh
+```
+
+For Fedora/RHEL: `sudo dnf install ffmpeg alsa-lib-devel`. For Arch: `sudo pacman -S ffmpeg alsa-lib`.
+
+You can also grab a binary directly from [Releases](https://github.com/giovannialberto/scriba/releases).
+
+### Run
+
+```bash
 scriba
 ```
 
@@ -58,7 +80,9 @@ Scriba exposes your recordings to Claude Desktop via the Model Context Protocol:
 }
 ```
 
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS).
+Add to your Claude Desktop config:
+- **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Linux:** `~/.config/Claude/claude_desktop_config.json`
 
 ## License
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+set -e
+
+REPO="giovannialberto/scriba"
+INSTALL_DIR="/usr/local/bin"
+
+# Detect platform
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Darwin)
+    case "$ARCH" in
+      x86_64) TARGET="x86_64-apple-darwin" ;;
+      arm64)  TARGET="aarch64-apple-darwin" ;;
+      *)      echo "Unsupported architecture: $ARCH"; exit 1 ;;
+    esac
+    ;;
+  Linux)
+    case "$ARCH" in
+      x86_64) TARGET="x86_64-unknown-linux-gnu" ;;
+      *)      echo "Unsupported architecture: $ARCH (pre-built binaries are x86_64 only)"; exit 1 ;;
+    esac
+    ;;
+  *)
+    echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Get latest release tag
+LATEST="$(curl -fsSL "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)"
+if [ -z "$LATEST" ]; then
+  echo "Failed to fetch latest release"; exit 1
+fi
+
+URL="https://github.com/$REPO/releases/download/$LATEST/scriba-$TARGET"
+echo "Installing scriba $LATEST for $TARGET..."
+
+TMPFILE="$(mktemp)"
+curl -fsSL "$URL" -o "$TMPFILE"
+chmod +x "$TMPFILE"
+
+if [ -w "$INSTALL_DIR" ]; then
+  mv "$TMPFILE" "$INSTALL_DIR/scriba"
+else
+  echo "Installing to $INSTALL_DIR (requires sudo)..."
+  sudo mv "$TMPFILE" "$INSTALL_DIR/scriba"
+fi
+
+echo "scriba installed to $INSTALL_DIR/scriba"
+scriba --version


### PR DESCRIPTION
## Summary
- Add `install.sh` script that auto-detects platform and downloads the latest release binary
- Update README with Linux installation instructions (Debian/Ubuntu, Fedora, Arch)
- Add Linux path for Claude Desktop MCP config
- Remove obsolete `.env.template`
- Stop gitignoring `Cargo.lock` (should be tracked for binary crates)
- Fix remaining old bot identity in release workflow tap section

## Test plan
- [ ] Verify `curl -fsSL .../install.sh | sh` works on a Linux x86_64 machine
- [x] Verify macOS brew install path is unchanged
- [x] Verify README renders correctly on GitHub