### PR TITLE
feat: notify user when a new version is available

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -138,6 +138,13 @@ pub struct ScribaConfig {
     /// Preserved cloud provider when switching from Cloud to Private mode.
     #[serde(default)]
     pub last_cloud_provider: Option<CloudProvider>,
+    /// Check for updates on launch (default: true).
+    #[serde(default = "default_true")]
+    pub check_for_updates: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 /// Configuration for voice-activated recording ("Scriba Forever" mode).
@@ -581,6 +588,7 @@ impl Default for ScribaConfig {
             voice: VoiceConfig::default(),
             last_local_model: None,
             last_cloud_provider: None,
+            check_for_updates: true,
         }
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -127,6 +127,13 @@ pub struct Dashboard {
 
     // Easter egg
     pub(super) owl_easter_egg_frame: Option<usize>,
+
+    // Update checker
+    pub(super) update_available: Option<String>,                // Some("0.26.0") when newer version exists
+    pub(super) update_check_rx: Option<mpsc::Receiver<Option<String>>>,
+    pub(super) update_in_progress: bool,
+    pub(super) update_task: Option<tokio::task::JoinHandle<Result<String, String>>>,
+    pub(super) update_completed: Option<Result<String, String>>,  // Ok(version) or Err(message)
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -246,6 +253,13 @@ impl Dashboard {
 
             // Easter egg
             owl_easter_egg_frame: None,
+
+            // Update checker
+            update_available: None,
+            update_check_rx: None,
+            update_in_progress: false,
+            update_task: None,
+            update_completed: None,
         })
     }
 
@@ -260,6 +274,17 @@ impl Dashboard {
         // Load initial data
         self.load_recordings()?;
         self.load_stats()?;
+
+        // Spawn async update check (non-blocking, silent on failure)
+        if self.config.check_for_updates {
+            let (tx, rx) = mpsc::channel(1);
+            self.update_check_rx = Some(rx);
+            let current_version = env!("CARGO_PKG_VERSION").to_string();
+            tokio::spawn(async move {
+                let result = check_for_update(&current_version).await;
+                let _ = tx.send(result).await;
+            });
+        }
 
         // Check if onboarding is needed (no world.md exists)
         if !WorldContext::exists() {
@@ -492,6 +517,36 @@ impl Dashboard {
                 }
             }
 
+            // Check for update version check completion
+            if let Some(ref mut rx) = self.update_check_rx {
+                if let Ok(result) = rx.try_recv() {
+                    if let Some(version) = result {
+                        self.update_available = Some(version);
+                    }
+                    self.update_check_rx = None;
+                }
+            }
+
+            // Check for update task completion
+            if let Some(ref task) = self.update_task {
+                if task.is_finished() {
+                    let completed = self.update_task.take().unwrap();
+                    self.update_in_progress = false;
+                    match completed.await {
+                        Ok(Ok(version)) => {
+                            self.update_available = None;
+                            self.update_completed = Some(Ok(version));
+                        }
+                        Ok(Err(msg)) => {
+                            self.update_completed = Some(Err(msg));
+                        }
+                        Err(_) => {
+                            self.update_completed = Some(Err("Update task failed".to_string()));
+                        }
+                    }
+                }
+            }
+
             // Update progress animation if active (throttled)
             if anim_tick && self.progress_animation.is_some() {
                 self.update_progress_message();
@@ -639,6 +694,29 @@ impl Dashboard {
 
         if self.show_file_dialog {
             return self.handle_file_dialog_keys(key_code).await;
+        }
+
+        // Update banner: u to update, Esc to dismiss
+        if self.update_available.is_some() && !self.update_in_progress {
+            match key_code {
+                KeyCode::Char('u') | KeyCode::Char('U') => {
+                    let version = self.update_available.as_ref().unwrap().clone();
+                    self.update_in_progress = true;
+                    self.update_task = Some(tokio::spawn(async move {
+                        perform_update(&version).await
+                    }));
+                    return Ok(DashboardAction::Continue);
+                }
+                KeyCode::Esc => {
+                    self.update_available = None;
+                    return Ok(DashboardAction::Continue);
+                }
+                _ => {} // other keys fall through
+            }
+        }
+        // Dismiss update completion message on any keypress
+        if self.update_completed.is_some() {
+            self.update_completed = None;
         }
 
         // Dismiss notification on any keypress (without consuming the key)
@@ -897,6 +975,57 @@ impl Dashboard {
                 .style(style)
                 .alignment(Alignment::Center);
             f.render_widget(para, aligned);
+            return;
+        }
+
+        // Update completion message
+        if let Some(ref result) = self.update_completed {
+            let (msg, style) = match result {
+                Ok(v) => (
+                    format!("Updated to v{} \u{2014} restart Scriba to use it", v),
+                    Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                ),
+                Err(e) => (
+                    format!("Update failed: {}", e),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                ),
+            };
+            let para = Paragraph::new(msg).style(style).alignment(Alignment::Center);
+            f.render_widget(para, aligned);
+            return;
+        }
+
+        // Update available banner
+        if let Some(ref version) = self.update_available {
+            if self.update_in_progress {
+                let braille = ['\u{28F7}', '\u{28EF}', '\u{28DF}', '\u{28BF}', '\u{287F}', '\u{28FE}', '\u{28FD}', '\u{28FB}'];
+                let frame = self.progress_frame;
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("{} ", braille[frame % braille.len()]),
+                        Style::default().fg(ACCENT),
+                    ),
+                    Span::styled(
+                        format!("Updating to v{}...", version),
+                        Style::default().fg(Color::DarkGray),
+                    ),
+                ]);
+                f.render_widget(Paragraph::new(line).alignment(Alignment::Center), aligned);
+            } else {
+                let line = Line::from(vec![
+                    Span::styled(
+                        format!("v{} available ", version),
+                        Style::default().fg(ACCENT),
+                    ),
+                    Span::styled("[", Style::default().fg(Color::DarkGray)),
+                    Span::styled("u", Style::default().fg(Color::White)),
+                    Span::styled("] Update  ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("[", Style::default().fg(Color::DarkGray)),
+                    Span::styled("Esc", Style::default().fg(Color::White)),
+                    Span::styled("] Dismiss", Style::default().fg(Color::DarkGray)),
+                ]);
+                f.render_widget(Paragraph::new(line).alignment(Alignment::Center), aligned);
+            }
             return;
         }
 
@@ -1743,4 +1872,136 @@ impl Dashboard {
             );
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Update checker
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Check GitHub releases for a newer version. Returns `Some("X.Y.Z")` if available.
+async fn check_for_update(current_version: &str) -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .ok()?;
+    let resp = client
+        .get("https://api.github.com/repos/giovannialberto/scriba/releases/latest")
+        .header("User-Agent", "scriba")
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let json: serde_json::Value = resp.json().await.ok()?;
+    let tag = json["tag_name"].as_str()?;
+    let latest = tag.strip_prefix('v').unwrap_or(tag);
+    if version_newer(latest, current_version) {
+        Some(latest.to_string())
+    } else {
+        None
+    }
+}
+
+/// Simple semver comparison: is `a` newer than `b`?
+fn version_newer(a: &str, b: &str) -> bool {
+    let parse = |v: &str| -> Vec<u32> {
+        v.split('.').filter_map(|s| s.parse().ok()).collect()
+    };
+    let va = parse(a);
+    let vb = parse(b);
+    va > vb
+}
+
+/// Perform the actual update. Returns the new version string on success.
+async fn perform_update(version: &str) -> Result<String, String> {
+    let version_tag = if version.starts_with('v') {
+        version.to_string()
+    } else {
+        format!("v{}", version)
+    };
+
+    // Check if installed via Homebrew
+    if cfg!(target_os = "macos") {
+        let brew_check = tokio::process::Command::new("brew")
+            .args(["list", "scriba"])
+            .output()
+            .await;
+        if let Ok(output) = brew_check {
+            if output.status.success() {
+                // Update via Homebrew
+                let result = tokio::process::Command::new("brew")
+                    .args(["upgrade", "scriba"])
+                    .output()
+                    .await
+                    .map_err(|e| format!("brew upgrade failed: {}", e))?;
+                if result.status.success() {
+                    return Ok(version.to_string());
+                }
+                return Err(String::from_utf8_lossy(&result.stderr).to_string());
+            }
+        }
+    }
+
+    // Direct binary replacement (macOS non-Homebrew + Linux)
+    let target = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-apple-darwin"
+        } else {
+            "x86_64-apple-darwin"
+        }
+    } else if cfg!(target_os = "linux") {
+        "x86_64-unknown-linux-gnu"
+    } else {
+        return Err("Unsupported platform".to_string());
+    };
+
+    let url = format!(
+        "https://github.com/giovannialberto/scriba/releases/download/{}/scriba-{}",
+        version_tag, target
+    );
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(120))
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let resp = client
+        .get(&url)
+        .header("User-Agent", "scriba")
+        .send()
+        .await
+        .map_err(|e| format!("Download failed: {}", e))?;
+
+    if !resp.status().is_success() {
+        return Err(format!("Download failed: HTTP {}", resp.status()));
+    }
+
+    let bytes = resp
+        .bytes()
+        .await
+        .map_err(|e| format!("Download failed: {}", e))?;
+
+    // Write to temp file, then replace current binary
+    let current_exe = std::env::current_exe().map_err(|e| e.to_string())?;
+    let tmp_path = current_exe.with_extension("update");
+
+    tokio::fs::write(&tmp_path, &bytes)
+        .await
+        .map_err(|e| format!("Failed to write update: {}", e))?;
+
+    // Make executable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&tmp_path, perms)
+            .map_err(|e| format!("Failed to set permissions: {}", e))?;
+    }
+
+    // Atomic replace
+    std::fs::rename(&tmp_path, &current_exe)
+        .map_err(|e| format!("Failed to replace binary: {}", e))?;
+
+    Ok(version.to_string())
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -552,8 +552,8 @@ impl Dashboard {
                 self.update_progress_message();
             }
 
-            // Tick progress frame for inline transcription animation (throttled)
-            if anim_tick && (self.active_transcription.is_some() || !self.transcription_queue.is_empty()) {
+            // Tick progress frame for inline transcription/update animation (throttled)
+            if anim_tick && (self.active_transcription.is_some() || !self.transcription_queue.is_empty() || self.update_in_progress) {
                 self.progress_frame = self.progress_frame.wrapping_add(1);
             }
 

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -26,8 +26,8 @@ const IDX_MODE: usize = 0;
 const PRIVATE_MODE_ITEMS: usize = 3;
 /// Number of mode-specific items in Cloud mode (Whisper API Key, LLM Provider, Model, Provider API Key).
 const CLOUD_MODE_ITEMS: usize = 4;
-/// Number of shared items (Auto-Stop, Timeout).
-const SHARED_ITEMS: usize = 2;
+/// Number of shared items (Auto-Stop, Timeout, Check for Updates).
+const SHARED_ITEMS: usize = 3;
 
 /// First shared-section index for a given mode.
 fn shared_offset(is_private: bool) -> usize {
@@ -408,6 +408,15 @@ impl Dashboard {
                                     }
                                 }
                             }
+                            2 => {
+                                // Toggle check for updates
+                                self.config.check_for_updates = !self.config.check_for_updates;
+                                if let Err(e) = self.config.save() {
+                                    self.message = format!("Failed to save setting: {}", e);
+                                    self.show_message = true;
+                                    self.return_to_view = Some(DashboardView::Settings);
+                                }
+                            }
                             _ => {}
                         }
                     }
@@ -686,6 +695,13 @@ impl Dashboard {
         let timeout_style_override = if !silence_enabled { Some(val_disabled) } else { None };
         let timeout_hint = if silence_enabled { "\u{2190} Enter to cycle" } else { "(enable auto-stop first)" };
         setting_line!("Timeout", timeout_display, shared_off + 1, timeout_hint, timeout_style_override);
+
+        // ── GENERAL ─────────────────────────────────────────────────
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![Span::raw("  "), Span::styled("GENERAL", section_style)]));
+
+        let updates_value = if self.config.check_for_updates { "Enabled" } else { "Disabled" };
+        setting_line!("Check for Updates", updates_value, shared_off + 2, "\u{2190} Enter to toggle", None::<Style>);
 
         let body = Paragraph::new(lines).style(Style::default().fg(Color::White));
         f.render_widget(body, chunks[1]);


### PR DESCRIPTION
## Summary
- On startup, async check GitHub releases API for newer versions (never blocks the UI)
- Show a subtle banner in the footer: `v0.26.0 available [u] Update [Esc] Dismiss`
- Pressing `u` auto-updates in-place: Homebrew upgrade on macOS if installed via Homebrew, direct binary download + replace otherwise
- Shows spinner during update, then "Updated — restart Scriba to use vX.Y.Z"
- `Esc` dismisses the banner until next launch
- "Check for Updates" toggle in Settings (GENERAL section) to opt out entirely
- Fails silently on network errors (offline, timeout, etc.)

Closes #82

## Test plan
- [x] Launch with current version → no banner shown
- [x] Launch with older version (or mock newer release) → banner appears in footer
- [x] Press `Esc` → banner dismissed, normal footer returns
- [x] Press `u` → update spinner shown, binary replaced, success message
- [x] Disable "Check for Updates" in Settings → no check on next launch
- [x] Offline/no network → app starts normally, no errors