### PR TITLE
fix: agent can now filter recordings by date

### DIFF
--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -63,7 +63,12 @@ pub fn summarize_tool_result(name: &str, result: &str) -> String {
             if result.contains("not found") {
                 "not found".to_string()
             } else {
-                format!("{} chars", char_count)
+                let mentions = result.matches("\"recording_id\"").count();
+                if mentions > 0 {
+                    format!("{} mentions", mentions)
+                } else {
+                    "found".to_string()
+                }
             }
         }
         "get_recordings_for_entity" => {
@@ -116,12 +121,12 @@ pub fn summarize_input(name: &str, input: &Value) -> String {
             format!("id={}", id)
         }
         "get_entity" => {
-            let id = input
-                .get("id")
-                .and_then(|v| v.as_i64())
-                .map(|v| v.to_string())
-                .unwrap_or_else(|| "?".to_string());
-            format!("id={}", id)
+            if let Some(name) = input.get("name").and_then(|v| v.as_str()) {
+                format!("\"{}\"", name)
+            } else {
+                let id = input.get("id").and_then(|v| v.as_i64()).map(|v| v.to_string()).unwrap_or_else(|| "?".to_string());
+                format!("id={}", id)
+            }
         }
         "get_recordings_for_entity" => {
             let id = input

--- a/src/agent/tools.rs
+++ b/src/agent/tools.rs
@@ -38,12 +38,18 @@ pub fn summarize_tool_result(name: &str, result: &str) -> String {
             if result.contains("not found") {
                 "not found".to_string()
             } else {
-                format!("{} chars", char_count)
+                // Show what metadata is available
+                let mut has = Vec::new();
+                if result.contains("\"summary\"") { has.push("summary"); }
+                if result.contains("\"topics\"") { has.push("topics"); }
+                if result.contains("\"key_points\"") { has.push("key points"); }
+                if result.contains("\"action_items\"") { has.push("actions"); }
+                if has.is_empty() { "metadata".to_string() } else { has.join(", ") }
             }
         }
         "get_transcript" => {
             let word_count = result.split_whitespace().count();
-            format!("{} words", word_count)
+            format!("transcript, {} words", word_count)
         }
         "search_transcripts" => {
             let count = result.matches("\"recording_id\"").count();
@@ -91,7 +97,14 @@ pub fn summarize_input(name: &str, input: &Value) -> String {
     match name {
         "search_transcripts" => {
             let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("?");
-            format!("\"{}\"", query)
+            let mut parts = vec![format!("\"{}\"", query)];
+            if let Some(from) = input.get("from_date").and_then(|v| v.as_str()) {
+                parts.push(format!("from {}", from));
+            }
+            if let Some(to) = input.get("to_date").and_then(|v| v.as_str()) {
+                parts.push(format!("to {}", to));
+            }
+            parts.join(", ")
         }
         "get_recording" | "get_transcript" => {
             let id = input
@@ -119,11 +132,17 @@ pub fn summarize_input(name: &str, input: &Value) -> String {
             format!("entity_id={}", id)
         }
         "list_recordings" => {
-            if let Some(limit) = input.get("limit").and_then(|v| v.as_i64()) {
-                format!("limit={}", limit)
-            } else {
-                "all".to_string()
+            let mut parts = Vec::new();
+            if let Some(from) = input.get("from_date").and_then(|v| v.as_str()) {
+                parts.push(format!("from {}", from));
             }
+            if let Some(to) = input.get("to_date").and_then(|v| v.as_str()) {
+                parts.push(format!("to {}", to));
+            }
+            if let Some(limit) = input.get("limit").and_then(|v| v.as_i64()) {
+                parts.push(format!("limit={}", limit));
+            }
+            if parts.is_empty() { "all".to_string() } else { parts.join(", ") }
         }
         "list_entities" => {
             let mut parts = Vec::new();

--- a/src/database/repository.rs
+++ b/src/database/repository.rs
@@ -366,16 +366,16 @@ impl Database {
 
         if let Some(from) = from_date {
             conditions.push(format!("created_at >= ?{}", params_vec.len() + 1));
-            params_vec.push(Box::new(format!("{}T00:00:00", from)));
+            params_vec.push(Box::new(format!("{} 00:00:00", from)));
         }
         if let Some(to) = to_date {
             conditions.push(format!("created_at < ?{}", params_vec.len() + 1));
             // Add one day to make to_date inclusive
             if let Ok(d) = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d") {
                 let next_day = d + chrono::Duration::days(1);
-                params_vec.push(Box::new(format!("{}T00:00:00", next_day)));
+                params_vec.push(Box::new(format!("{} 00:00:00", next_day)));
             } else {
-                params_vec.push(Box::new(format!("{}T23:59:59", to)));
+                params_vec.push(Box::new(format!("{} 23:59:59", to)));
             }
         }
 
@@ -656,15 +656,15 @@ impl Database {
 
         if let Some(from) = from_date {
             sql.push_str(&format!(" AND r.created_at >= ?{}", params_vec.len() + 1));
-            params_vec.push(Box::new(format!("{}T00:00:00", from)));
+            params_vec.push(Box::new(format!("{} 00:00:00", from)));
         }
         if let Some(to) = to_date {
             sql.push_str(&format!(" AND r.created_at < ?{}", params_vec.len() + 1));
             if let Ok(d) = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d") {
                 let next_day = d + chrono::Duration::days(1);
-                params_vec.push(Box::new(format!("{}T00:00:00", next_day)));
+                params_vec.push(Box::new(format!("{} 00:00:00", next_day)));
             } else {
-                params_vec.push(Box::new(format!("{}T23:59:59", to)));
+                params_vec.push(Box::new(format!("{} 23:59:59", to)));
             }
         }
 

--- a/src/database/repository.rs
+++ b/src/database/repository.rs
@@ -350,20 +350,50 @@ impl Database {
         limit: Option<i64>,
         offset: Option<i64>,
     ) -> Result<Vec<Recording>> {
-        let sql = match (limit, offset) {
-            (Some(l), Some(o)) => format!(
-                "SELECT * FROM recordings ORDER BY created_at DESC LIMIT {} OFFSET {}",
-                l, o
-            ),
-            (Some(l), None) => format!(
-                "SELECT * FROM recordings ORDER BY created_at DESC LIMIT {}",
-                l
-            ),
-            _ => "SELECT * FROM recordings ORDER BY created_at DESC".to_string(),
-        };
+        self.list_recordings_filtered(limit, offset, None, None)
+    }
+
+    pub fn list_recordings_filtered(
+        &self,
+        limit: Option<i64>,
+        offset: Option<i64>,
+        from_date: Option<&str>,
+        to_date: Option<&str>,
+    ) -> Result<Vec<Recording>> {
+        let mut sql = String::from("SELECT * FROM recordings");
+        let mut conditions: Vec<String> = Vec::new();
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(from) = from_date {
+            conditions.push(format!("created_at >= ?{}", params_vec.len() + 1));
+            params_vec.push(Box::new(format!("{}T00:00:00", from)));
+        }
+        if let Some(to) = to_date {
+            conditions.push(format!("created_at < ?{}", params_vec.len() + 1));
+            // Add one day to make to_date inclusive
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d") {
+                let next_day = d + chrono::Duration::days(1);
+                params_vec.push(Box::new(format!("{}T00:00:00", next_day)));
+            } else {
+                params_vec.push(Box::new(format!("{}T23:59:59", to)));
+            }
+        }
+
+        if !conditions.is_empty() {
+            sql.push_str(" WHERE ");
+            sql.push_str(&conditions.join(" AND "));
+        }
+        sql.push_str(" ORDER BY created_at DESC");
+        if let Some(l) = limit {
+            sql.push_str(&format!(" LIMIT {}", l));
+        }
+        if let Some(o) = offset {
+            sql.push_str(&format!(" OFFSET {}", o));
+        }
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([], row_to_recording)?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), row_to_recording)?;
 
         let mut recordings = Vec::new();
         for row in rows {
@@ -605,30 +635,47 @@ impl Database {
         query: &str,
         limit: Option<i64>,
     ) -> Result<Vec<(Recording, Transcript)>> {
-        let sql = match limit {
-            Some(l) => format!(
-                r#"
-                SELECT r.*, t.* FROM recordings r
-                JOIN transcripts t ON r.id = t.recording_id
-                JOIN transcripts_fts ON transcripts_fts.rowid = t.id
-                WHERE transcripts_fts MATCH ?1
-                ORDER BY rank
-                LIMIT {}
-            "#,
-                l
-            ),
-            None => r#"
-                SELECT r.*, t.* FROM recordings r
-                JOIN transcripts t ON r.id = t.recording_id
-                JOIN transcripts_fts ON transcripts_fts.rowid = t.id
-                WHERE transcripts_fts MATCH ?1
-                ORDER BY rank
-            "#
-            .to_string(),
-        };
+        self.search_transcripts_filtered(query, limit, None, None)
+    }
+
+    pub fn search_transcripts_filtered(
+        &self,
+        query: &str,
+        limit: Option<i64>,
+        from_date: Option<&str>,
+        to_date: Option<&str>,
+    ) -> Result<Vec<(Recording, Transcript)>> {
+        let mut sql = String::from(
+            r#"SELECT r.*, t.* FROM recordings r
+               JOIN transcripts t ON r.id = t.recording_id
+               JOIN transcripts_fts ON transcripts_fts.rowid = t.id
+               WHERE transcripts_fts MATCH ?1"#,
+        );
+        let mut params_vec: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+        params_vec.push(Box::new(query.to_string()));
+
+        if let Some(from) = from_date {
+            sql.push_str(&format!(" AND r.created_at >= ?{}", params_vec.len() + 1));
+            params_vec.push(Box::new(format!("{}T00:00:00", from)));
+        }
+        if let Some(to) = to_date {
+            sql.push_str(&format!(" AND r.created_at < ?{}", params_vec.len() + 1));
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d") {
+                let next_day = d + chrono::Duration::days(1);
+                params_vec.push(Box::new(format!("{}T00:00:00", next_day)));
+            } else {
+                params_vec.push(Box::new(format!("{}T23:59:59", to)));
+            }
+        }
+
+        sql.push_str(" ORDER BY rank");
+        if let Some(l) = limit {
+            sql.push_str(&format!(" LIMIT {}", l));
+        }
 
         let mut stmt = self.conn.prepare(&sql)?;
-        let rows = stmt.query_map([query], row_to_recording_and_transcript)?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt.query_map(param_refs.as_slice(), row_to_recording_and_transcript)?;
 
         let mut results = Vec::new();
         for row in rows {

--- a/src/enrichment/chat_prompts.rs
+++ b/src/enrichment/chat_prompts.rs
@@ -163,13 +163,17 @@ Keep it concise and professional."#,
 /// Build the system prompt for the agent (global context).
 /// Much simpler than the flat prompt — the agent fetches data via tools.
 pub fn build_agent_global_prompt(owner_name: &str) -> String {
+    let today = chrono::Local::now().format("%A, %B %-d, %Y").to_string();
     format!(
         r#"You are Scriba, {owner}'s personal audio assistant. You record, transcribe, and remember everything.
+
+Today is {today}.
 
 You have access to tools to search and read recordings, transcripts, entities, and the owner's world context.
 
 ## How to work
 - ALWAYS use your tools to find information before answering — do not guess.
+- When the user refers to time ("today", "yesterday", "this week"), use the from_date/to_date filters on list_recordings or search_transcripts to narrow results.
 - When cross-correlating topics across recordings, search first, then read the relevant transcripts.
 - Think step by step. Use multiple tool calls if needed.
 - After gathering information, synthesize a clear, concise answer.
@@ -183,6 +187,7 @@ You have access to tools to search and read recordings, transcripts, entities, a
 - Be concise — 2-5 sentences unless the user asks for detail.
 - Never fabricate information about recordings or entities you haven't looked up."#,
         owner = owner_name,
+        today = today,
     )
 }
 
@@ -194,8 +199,11 @@ pub fn build_agent_recording_prompt(
     recording_name: &str,
     summary: &str,
 ) -> String {
+    let today = chrono::Local::now().format("%A, %B %-d, %Y").to_string();
     format!(
         r#"You are Scriba, {owner}'s personal audio assistant. You are currently helping with a specific recording.
+
+Today is {today}.
 
 ## Current Recording
 - ID: {id}

--- a/src/tools/definitions.rs
+++ b/src/tools/definitions.rs
@@ -23,6 +23,10 @@ pub struct ListRecordingsParams {
     pub limit: Option<i64>,
     /// Number of items to skip.
     pub offset: Option<i64>,
+    /// Only include recordings from this date onward (ISO 8601, e.g. "2026-04-10").
+    pub from_date: Option<String>,
+    /// Only include recordings up to this date (ISO 8601, e.g. "2026-04-10").
+    pub to_date: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -47,6 +51,10 @@ pub struct SearchTranscriptsParams {
     pub query: String,
     /// Maximum results to return. Default: 10.
     pub limit: Option<i64>,
+    /// Only include recordings from this date onward (ISO 8601, e.g. "2026-04-10").
+    pub from_date: Option<String>,
+    /// Only include recordings up to this date (ISO 8601, e.g. "2026-04-10").
+    pub to_date: Option<String>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -132,7 +140,7 @@ pub fn all_tool_schemas() -> Vec<ToolSchema> {
     vec![
         ToolSchema {
             name: "list_recordings",
-            description: "List all recordings with metadata (id, name, date, duration, summary snippet). Use this to see what recordings are available.",
+            description: "List all recordings with metadata (id, name, date, duration, summary snippet). Supports date filtering with from_date/to_date (ISO 8601). Use this to see what recordings are available.",
             input_schema: serde_json::to_value(schemars::schema_for!(ListRecordingsParams)).unwrap(),
         },
         ToolSchema {
@@ -147,7 +155,7 @@ pub fn all_tool_schemas() -> Vec<ToolSchema> {
         },
         ToolSchema {
             name: "search_transcripts",
-            description: "Full-text search across all transcripts. Returns matching recording IDs with snippets. Use this to find recordings about a topic.",
+            description: "Full-text search across all transcripts. Returns matching recording IDs with snippets. Supports date filtering with from_date/to_date (ISO 8601). Use this to find recordings about a topic.",
             input_schema: serde_json::to_value(schemars::schema_for!(SearchTranscriptsParams)).unwrap(),
         },
         ToolSchema {

--- a/src/tools/executor.rs
+++ b/src/tools/executor.rs
@@ -57,7 +57,7 @@ fn exec_list_recordings(input: &Value, db: &Database) -> ToolResult {
         Ok(p) => p,
         Err(e) => return ToolResult::err(format!("Invalid params: {}", e)),
     };
-    match db.list_recordings(params.limit, params.offset) {
+    match db.list_recordings_filtered(params.limit, params.offset, params.from_date.as_deref(), params.to_date.as_deref()) {
         Ok(recordings) => {
             let items: Vec<Value> = recordings
                 .iter()
@@ -150,7 +150,7 @@ fn exec_search_transcripts(input: &Value, db: &Database) -> ToolResult {
         Err(e) => return ToolResult::err(format!("Invalid params: {}", e)),
     };
     let limit = params.limit.or(Some(10));
-    match db.search_transcripts(&params.query, limit) {
+    match db.search_transcripts_filtered(&params.query, limit, params.from_date.as_deref(), params.to_date.as_deref()) {
         Ok(results) => {
             let items: Vec<Value> = results
                 .iter()


### PR DESCRIPTION
## Summary
- Agent system prompt now includes the current date (e.g. "Today is Thursday, April 10, 2026") so it can resolve time references like "today", "yesterday", "this week"
- Prompt instructs the agent to use date filters when the user refers to time
- `list_recordings` and `search_transcripts` tools now accept optional `from_date` / `to_date` parameters (ISO 8601)
- Database queries filter on the existing `created_at` index — `to_date` is inclusive (includes the full day)
- Tool call summaries now show date filters, entity names, and descriptive metadata instead of opaque char counts

Closes #84

## Test plan
- [x] Ask "what recordings do I have from today?" → only today's recordings returned
- [x] Ask "looking at the presentations I gave today" → correct recordings, not older ones
- [x] Search without date filters → works as before (no regression)
- [x] `list_recordings` with `from_date` only, `to_date` only, both → correct filtering