### PR TITLE
fix: improve browser UX — transcribe hint and column alignment

### DIFF
--- a/src/tui/browse.rs
+++ b/src/tui/browse.rs
@@ -547,6 +547,9 @@ impl Dashboard {
 
         let mut right_spans = vec![
             Span::styled("[", Style::default().fg(Color::DarkGray)),
+            Span::styled("T", Style::default().fg(Color::White)),
+            Span::styled("] Transcribe  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("[", Style::default().fg(Color::DarkGray)),
             Span::styled("Tab", Style::default().fg(Color::White)),
             Span::styled("] Home  ", Style::default().fg(Color::DarkGray)),
             Span::styled("[", Style::default().fg(Color::DarkGray)),
@@ -599,7 +602,7 @@ impl Dashboard {
         let mut line_to_recording: Vec<Option<usize>> = Vec::new();
         let mut current_group: Option<String> = None;
 
-        let name_col_width = (area.width as usize).saturating_sub(16); // leave room for prefix + duration + time
+        let name_col_width = (area.width as usize).saturating_sub(2); // right margin matches left (2 chars)
 
         for (i, recording) in self.recordings.iter().enumerate() {
             let rec_date = recording.created_at.with_timezone(&chrono::Local).date_naive();

--- a/src/tui/browse.rs
+++ b/src/tui/browse.rs
@@ -568,7 +568,7 @@ impl Dashboard {
         // Compute widths to fill gap
         let left_width: usize = left_spans.iter().map(|s| s.content.chars().count()).sum();
         let right_width: usize = right_spans.iter().map(|s| s.content.chars().count()).sum();
-        let gap = (footer_area.width as usize).saturating_sub(left_width + right_width);
+        let gap = (footer_area.width as usize).saturating_sub(left_width + right_width).max(2);
 
         let mut spans = left_spans;
         spans.push(Span::raw(" ".repeat(gap)));
@@ -602,7 +602,7 @@ impl Dashboard {
         let mut line_to_recording: Vec<Option<usize>> = Vec::new();
         let mut current_group: Option<String> = None;
 
-        let name_col_width = (area.width as usize).saturating_sub(2); // right margin matches left (2 chars)
+        let name_col_width = (area.width as usize).saturating_sub(4); // right margin matches left visual margin
 
         for (i, recording) in self.recordings.iter().enumerate() {
             let rec_date = recording.created_at.with_timezone(&chrono::Local).date_naive();

--- a/src/tui/browse.rs
+++ b/src/tui/browse.rs
@@ -602,7 +602,7 @@ impl Dashboard {
         let mut line_to_recording: Vec<Option<usize>> = Vec::new();
         let mut current_group: Option<String> = None;
 
-        let name_col_width = (area.width as usize).saturating_sub(4); // right margin matches left visual margin
+        let name_col_width = (area.width as usize).saturating_sub(3); // right margin matches left visual margin
 
         for (i, recording) in self.recordings.iter().enumerate() {
             let rec_date = recording.created_at.with_timezone(&chrono::Local).date_naive();


### PR DESCRIPTION
## Summary
- Add `[T] Transcribe` hint to the browser footer so users discover they can re-transcribe recordings
- Fix column alignment: right margin reduced from 16 chars to 3 chars, matching the left margin
- Footer enforces minimum 2-char gap between stats and key hints when terminal is narrow

Closes #86

## Test plan
- [x] Browse view: duration and time columns are visually centered, not pushed far left
- [x] Browse view footer shows `[T] Transcribe  [Tab] Home  [Ctrl+R] Record`
- [x] Pressing T on a selected recording triggers transcription as before
- [x] Shrinking terminal keeps gap between stats and hints